### PR TITLE
Belts spawn optimization

### DIFF
--- a/Assets/BeltSystem.cs
+++ b/Assets/BeltSystem.cs
@@ -57,20 +57,20 @@ public class BeltSystem : ObjectWithBounds
         if (nextEdge - prevEdge < 0) return false; // No space to fit item
 
         if (item.Progress < prevEdge) item.Progress = prevEdge;
-        else if (item.Progress > nextEdge) item.Progress = nextEdge; 
+        else if (item.Progress > nextEdge) item.Progress = nextEdge;
 
         Items.Insert(start, item);
-        
+
 #if UNITY_EDITOR
         Check();
 #endif
-        
+
         return true;
     }
 
     private void Check()
     {
-        // TODO: For debug only, remove in production 
+        // TODO: For debug only, remove in production
         float prev = -100;
         foreach (ItemOnBelt item in Items)
         {

--- a/Assets/BeltSystem.cs
+++ b/Assets/BeltSystem.cs
@@ -25,6 +25,11 @@ public class BeltSystem : ObjectWithBounds
         Bounds.Expand(0.5f);
     }
 
+    public void PushItemRaw(ItemOnBelt item)
+    {
+        Items.Add(item);
+    }
+
     public bool PushItem(ItemOnBelt item)
     {
         int start = 0;

--- a/Assets/BeltsManager.cs
+++ b/Assets/BeltsManager.cs
@@ -38,7 +38,7 @@ public class BeltsManager : MonoBehaviour
         for (int i = 0; i < updatingThreads.Length; i++)
         {
             updatingThreads[i] = new Thread(parameter => UpdatePackThreadStarted((int) parameter, 4));
-			updatingThreads[i].IsBackground = true;
+            updatingThreads[i].IsBackground = true;
             updatingThreads[i].Start(i + 1);
         }
     }
@@ -80,7 +80,7 @@ public class BeltsManager : MonoBehaviour
     {
         float from = (float) packIndex / totalPacks;
         float to = (float) (packIndex + 1) / totalPacks;
-        
+
         for (int i = (int) (Belts.Count * from); i < (int) (Belts.Count * to); i++)
         {
             BeltSystem beltSystem = Belts[i];
@@ -98,7 +98,7 @@ public class BeltsManager : MonoBehaviour
                 items[j] = new ItemOnBelt(progress);
             }
         }
-        
+
         updatingBarrier.SignalAndWait();
 
         for (int i = (int) (Hands.Count * from); i < (int) (Hands.Count * to); i++)

--- a/Assets/BeltsManager.cs
+++ b/Assets/BeltsManager.cs
@@ -38,6 +38,7 @@ public class BeltsManager : MonoBehaviour
         for (int i = 0; i < updatingThreads.Length; i++)
         {
             updatingThreads[i] = new Thread(parameter => UpdatePackThreadStarted((int) parameter, 4));
+			updatingThreads[i].IsBackground = true;
             updatingThreads[i].Start(i + 1);
         }
     }

--- a/Assets/BeltsManager.cs
+++ b/Assets/BeltsManager.cs
@@ -84,7 +84,7 @@ public class BeltsManager : MonoBehaviour
         for (int i = (int) (Belts.Count * from); i < (int) (Belts.Count * to); i++)
         {
             BeltSystem beltSystem = Belts[i];
-            for (int j = 0; j < beltSystem.Items.Count - beltSystem.StuckItems; j++)
+            for (int j = beltSystem.Items.Count - beltSystem.StuckItems - 1; j >= 0; j--)
             {
                 var items = beltSystem.Items;
 

--- a/Assets/BeltsSpawner.cs
+++ b/Assets/BeltsSpawner.cs
@@ -5,8 +5,6 @@ using UnityEngine.UI;
 public class BeltsSpawner : MonoBehaviour
 {
     public BeltsManager Manager;
-    [FormerlySerializedAs("BeltSprite")] public SpriteRenderer BeltSpritePrefab;
-    public GameObject HandPrefab;
     public Text CountText;
 
     [FormerlySerializedAs("RowsCount")] public int Rows = 10;
@@ -15,8 +13,6 @@ public class BeltsSpawner : MonoBehaviour
     public int RowsNotInEditor = 1000;
     public int ColumnsNotInEditor = 10;
     public int BeltLength = 10;
-
-    private bool firstUpdate = true;
 
     private void Start()
     {
@@ -41,7 +37,9 @@ public class BeltsSpawner : MonoBehaviour
             }
         }
 
-        CountText.text = Rows * Columns * BeltLength + " belts";
+        CountText.text = Rows * Columns * BeltLength + " belts, " + Rows * Columns * (BeltLength - 2) + " items";
+
+        Destroy(this);
     }
 
     private void SpawnBelt(Vector2 offset, bool down)
@@ -61,6 +59,11 @@ public class BeltsSpawner : MonoBehaviour
         wayPoints[wayPoints.Length - 1] = offset + new Vector2(0, down ? -BeltLength : 0);
 
         var beltSystem = new BeltSystem(wayPoints, spritePositions) {Down = down};
+        for (int i = 1; i < BeltLength - 1; i++)
+        {
+            beltSystem.PushItemRaw(new ItemOnBelt(i));
+        }
+		
         Manager.Belts.Add(beltSystem);
         Manager.Objects.Insert(beltSystem);
     }
@@ -77,26 +80,5 @@ public class BeltsSpawner : MonoBehaviour
 
         Manager.Hands.Add(hand);
         Manager.Objects.Insert(hand);
-    }
-
-    private void Update()
-    {
-        if (firstUpdate)
-        {
-            for (int x = 0; x < Rows; x++)
-            {
-                for (int j = 0; j < Columns; j++)
-                {
-                    for (int i = 1; i < BeltLength - 1; i++)
-                    {
-                        Manager.SpawnItem(new Vector2(x * 2, -i - j * (BeltLength + 5)));
-                    }
-                }
-            }
-
-            CountText.text += "," + Rows * Columns * (BeltLength - 2) + " items";
-
-            firstUpdate = false;
-        }
     }
 }

--- a/Assets/BeltsSpawner.cs
+++ b/Assets/BeltsSpawner.cs
@@ -63,7 +63,7 @@ public class BeltsSpawner : MonoBehaviour
         {
             beltSystem.PushItemRaw(new ItemOnBelt(i));
         }
-		
+
         Manager.Belts.Add(beltSystem);
         Manager.Objects.Insert(beltSystem);
     }

--- a/Assets/QuadTree.cs
+++ b/Assets/QuadTree.cs
@@ -53,9 +53,9 @@ public class QuadTree
         {
             return false;
         }
-        
+
         if (objects.Remove(obj)) return true;
-        
+
         if (isDivided)
         {
             if (northEast.Remove(obj)) return true;

--- a/Assets/Scenes/Game.unity
+++ b/Assets/Scenes/Game.unity
@@ -476,10 +476,6 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   Manager: {fileID: 912728949}
-  BeltSpritePrefab: {fileID: 8756978109600218455, guid: 07d6f4bd64cadf14cb235204721b632e,
-    type: 3}
-  HandPrefab: {fileID: 28463208029751301, guid: 1ce5ba8724f859841ab911d8377e3a9b,
-    type: 3}
   CountText: {fileID: 360068312}
   Rows: 10
   Columns: 10


### PR DESCRIPTION
Не смог запустить собранный вариант даже после часа ожидания.
Эти обновления ускоряют запуск (в моём случае 2 секунды) и исправляют пару багов.

Автоматическое создание предметов перенесено в создание конвеера, пропуская поиск нужного конвеера и места.
Убраны неиспользуемые переменные и функция Update, добавлено самоуничтожение спавнера после инициализации.
Потоки отмечены как фоновые, позволяя приложению закрыться.
Предметы на конвеере обновляются с конца, исправляя баг с "отталкиванием" при "застревании" сразу нескольких предметов подряд.